### PR TITLE
Make `chess` module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@ mod compressed_move;
 mod compressed_position;
 mod training_data_file;
 
-pub mod chess;
 pub mod binpack_error;
+pub mod chess;
 pub mod reader;
 pub mod training_data_entry;
 pub mod writer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 mod arithmetic;
-mod chess;
 mod compressed_move;
 mod compressed_position;
 mod training_data_file;
 
+pub mod chess;
 pub mod binpack_error;
 pub mod reader;
 pub mod training_data_entry;


### PR DESCRIPTION
Needed for doing anything with the returned `TrainingDataEntry`