### PR TITLE
feat: automatically use _pdep when available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +122,7 @@ version = "0.6.2"
 dependencies = [
  "arrayvec",
  "js-sys",
+ "raw-cpuid",
  "tempfile",
  "thiserror",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,12 @@ readme = "README.md"
 [features]
 default = []
 
-# Enables the usage of `_pdep_u64` which will make the reader faster on modern hardware.
-# If disabled a fallback procedure is used.
-# This should be enabled on all Intel CPUs, which support BMI2.
-# CPUs from AMD should only enabled this if the architecture is Zen3+.
+# Kept for compatibility. BMI2 dispatch is selected automatically at runtime.
 bmi2 = []
 
 [dependencies]
 arrayvec = "0.7.6"
+raw-cpuid = "11.6.0"
 thiserror = "2.0.8"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -15,17 +15,18 @@ such as `CompressedTrainingDataEntryReader::from_bytes`,
 
 ## Compile
 
-If your machine has the fast BMI2 instruction set (Zen 3+), you should enable the feature flag
+Starting with crate version `0.6.3`, fast BMI2 runtime dispatch is enabled by default.
+You do not need to pass a feature flag or add one in `Cargo.toml`.
 
 ```bash
-cargo build --release --features bmi2;
+cargo build --release
 ```
 
-or define it in your `Cargo.toml` file (change version).
+In `Cargo.toml`:
 
 ```
 [dependencies]
-binpack = { version = "0.4.3", features = ["bmi2"] }
+sfbinpack = "0.6.3"
 ```
 
 ## Usage

--- a/src/common/arithmetic.rs
+++ b/src/common/arithmetic.rs
@@ -1,10 +1,55 @@
-#[cfg(all(target_arch = "x86_64", any(target_feature = "bmi2", feature = "bmi2")))]
+#[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::_pdep_u64;
+#[cfg(target_arch = "x86_64")]
+use std::sync::atomic::{AtomicPtr, Ordering::Relaxed};
 
-#[cfg(all(target_arch = "x86_64", any(target_feature = "bmi2", feature = "bmi2")))]
+#[cfg(target_arch = "x86_64")]
+type NthSetBitIndexFn = fn(u64, u64) -> u32;
+
+#[cfg(target_arch = "x86_64")]
+static NTH_SET_BIT_INDEX_BOOTSTRAP_FN: NthSetBitIndexFn = nth_set_bit_index_bootstrap;
+
+#[cfg(target_arch = "x86_64")]
+static NTH_SET_BIT_INDEX_BMI2_DISPATCH_FN: NthSetBitIndexFn = nth_set_bit_index_bmi2_dispatch;
+
+#[cfg(target_arch = "x86_64")]
+static NTH_SET_BIT_INDEX_FALLBACK_FN: NthSetBitIndexFn = nth_set_bit_index_fallback;
+
+#[cfg(target_arch = "x86_64")]
+static NTH_SET_BIT_INDEX_DISPATCH: AtomicPtr<NthSetBitIndexFn> =
+    AtomicPtr::new(&NTH_SET_BIT_INDEX_BOOTSTRAP_FN as *const _ as *mut _);
+
+#[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "bmi2")]
 unsafe fn nth_set_bit_index_bmi2(v: u64, n: u64) -> u32 {
     _pdep_u64(1u64 << n, v).trailing_zeros() as u32
+}
+
+#[cfg(target_arch = "x86_64")]
+fn nth_set_bit_index_bmi2_dispatch(v: u64, n: u64) -> u32 {
+    unsafe { nth_set_bit_index_bmi2(v, n) }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+fn nth_set_bit_index_dispatch(v: u64, n: u64) -> u32 {
+    let fn_ptr = NTH_SET_BIT_INDEX_DISPATCH.load(Relaxed);
+    let selected_fn = unsafe { *fn_ptr };
+    selected_fn(v, n)
+}
+
+#[cfg(target_arch = "x86_64")]
+fn nth_set_bit_index_bootstrap(v: u64, n: u64) -> u32 {
+    let selected_fn = if super::cpu_features::has_fast_bmi2() {
+        &NTH_SET_BIT_INDEX_BMI2_DISPATCH_FN as *const _ as *mut _
+    } else {
+        &NTH_SET_BIT_INDEX_FALLBACK_FN as *const _ as *mut _
+    };
+
+    NTH_SET_BIT_INDEX_DISPATCH.store(selected_fn, Relaxed);
+
+    let selected_fn = unsafe { *selected_fn };
+    selected_fn(v, n)
 }
 
 const fn nth_set_bit_index_naive(mut value: u64, n: usize) -> u8 {
@@ -35,14 +80,18 @@ const fn create_lookup_table() -> [[u8; 8]; 256] {
 
 const NTH_SET_BIT_INDEX: [[u8; 8]; 256] = create_lookup_table();
 
-#[allow(unreachable_code)]
 #[inline(always)]
 pub fn nth_set_bit_index(v: u64, n: u64) -> u32 {
-    #[cfg(all(target_arch = "x86_64", any(target_feature = "bmi2", feature = "bmi2")))]
-    unsafe {
-        return nth_set_bit_index_bmi2(v, n);
+    #[cfg(target_arch = "x86_64")]
+    {
+        return nth_set_bit_index_dispatch(v, n);
     }
 
+    nth_set_bit_index_fallback(v, n)
+}
+
+#[inline(always)]
+fn nth_set_bit_index_fallback(v: u64, n: u64) -> u32 {
     let mut value = v;
     let mut count = n;
 

--- a/src/common/arithmetic.rs
+++ b/src/common/arithmetic.rs
@@ -22,7 +22,7 @@ static NTH_SET_BIT_INDEX_DISPATCH: AtomicPtr<NthSetBitIndexFn> =
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "bmi2")]
 unsafe fn nth_set_bit_index_bmi2(v: u64, n: u64) -> u32 {
-    _pdep_u64(1u64 << n, v).trailing_zeros() as u32
+    _pdep_u64(1u64 << n, v).trailing_zeros()
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -81,6 +81,7 @@ const fn create_lookup_table() -> [[u8; 8]; 256] {
 const NTH_SET_BIT_INDEX: [[u8; 8]; 256] = create_lookup_table();
 
 #[inline(always)]
+#[allow(unreachable_code)]
 pub fn nth_set_bit_index(v: u64, n: u64) -> u32 {
     #[cfg(target_arch = "x86_64")]
     {

--- a/src/common/cpu_features.rs
+++ b/src/common/cpu_features.rs
@@ -1,0 +1,37 @@
+#[cfg(target_arch = "x86_64")]
+use raw_cpuid::CpuId;
+
+#[cfg(target_arch = "x86_64")]
+pub(crate) fn has_fast_bmi2() -> bool {
+    if !std::is_x86_feature_detected!("bmi2") {
+        return false;
+    }
+
+    !has_slow_bmi2()
+}
+
+#[cfg(target_arch = "x86_64")]
+fn has_slow_bmi2() -> bool {
+    let cpuid = CpuId::new();
+
+    if !cpuid
+        .get_vendor_info()
+        .is_some_and(|vendor| matches!(vendor.as_str(), "AuthenticAMD" | "AMD" | "HygonGenuine"))
+    {
+        return false;
+    }
+
+    let Some(feature_info) = cpuid.get_feature_info() else {
+        return false;
+    };
+
+    match (feature_info.family_id(), feature_info.model_id()) {
+        // Excavator / bdver4.
+        (0x15, 0x60..=0x7f) => true,
+        // Zen, Zen+, Zen 2.
+        (0x17, _) => true,
+        // Hygon Dhyana.
+        (0x18, _) => true,
+        _ => false,
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,8 +1,8 @@
 pub mod arithmetic;
 pub mod binpack_error;
-pub(crate) mod cpu_features;
 pub mod compressed_move;
 pub mod compressed_position;
 pub mod compressed_training_file_reader;
 pub mod compressed_training_file_writer;
+pub(crate) mod cpu_features;
 pub mod entry;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,5 +1,6 @@
 pub mod arithmetic;
 pub mod binpack_error;
+pub(crate) mod cpu_features;
 pub mod compressed_move;
 pub mod compressed_position;
 pub mod compressed_training_file_reader;


### PR DESCRIPTION
Uses runtime dispatch logic to use _pdep when the CPU has bmi2 and the function isn't microcoded. 

```
auto-detect-bmi2:

Processed:    133925670 entries |     17 392 939 entries/sec | elapsed:      7.7s


main:

Processed:     92453586 entries |     14 007 260 entries/sec | elapsed:      6.6s


main+bmi2:

Processed:    121619157 entries |     17 374 062 entries/sec | elapsed:      7.0s

```